### PR TITLE
Add support for theme sensitive profile pics on the about page

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -17,21 +17,35 @@ layout: default
  <article>
     {% if page.profile %}
       <div class="profile float-{% if page.profile.align == 'left' %}left{% else %}right{% endif %}">
-        {% if page.profile.image %}
-          {% assign profile_image_path = page.profile.image | prepend: 'assets/img/' %}
-          {% if page.profile.image_circular %}
-            {% assign profile_image_class = 'img-fluid z-depth-1 rounded-circle' %}
-          {% else %}
-            {% assign profile_image_class = 'img-fluid z-depth-0
-      rounded' %}
+
+        <!-- Prioritise theme sensitive profile images  -->
+        {% if page.profile.image_light and page.profile.image_dark %}
+          {% assign profile_image_light_path = page.profile.image_light | prepend: 'assets/img/' %}
+          {% assign profile_image_dark_path = page.profile.image_dark | prepend: 'assets/img/' %}
+
+          {% assign profile_image_class = 'img-fluid z-depth-0' %}
+
+          <img id="profile-image-theme" class="{{ profile_image_class }}" data-light="{{ profile_image_light_path }}" data-dark="{{ profile_image_dark_path }}" alt="{{ page.profile.image_alt }}">
+
+        {% else %}
+
+          {% if page.profile.image %}
+            {% assign profile_image_path = page.profile.image | prepend: 'assets/img/' %}
+            {% if page.profile.image_circular %}
+              {% assign profile_image_class = 'img-fluid z-depth-1 rounded-circle' %}
+            {% else %}
+              {% assign profile_image_class = 'img-fluid z-depth-0
+        rounded' %}
+            {% endif %}
+            {% capture sizes %}(min-width: {{site.max_width}}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 576px)
+        30vw, 95vw"{% endcapture %}
+            {%
+              include figure.liquid loading="eager" path=profile_image_path class=profile_image_class sizes=sizes alt=page.profile.image
+              cache_bust=true
+            %}
           {% endif %}
-          {% capture sizes %}(min-width: {{site.max_width}}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 576px)
-      30vw, 95vw"{% endcapture %}
-          {%
-            include figure.liquid loading="eager" path=profile_image_path class=profile_image_class sizes=sizes alt=page.profile.image
-            cache_bust=true
-          %}
         {% endif %}
+
         {% if page.profile.more_info %}
           <div class="more-info">{{ page.profile.more_info }}</div>
         {% endif %}
@@ -78,4 +92,3 @@ layout: default
     {% endif %}
   </article>
 </div>
-

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,8 +7,8 @@ subtitle: <a href='#'></a>
 profile:
   align: right
   image: logo_480.jpeg
-  light: logo_480.jpeg
-  dark: logo_black_480.jpg
+  image_light: logo_480.jpeg
+  image_dark: logo_black_480.jpeg
   image_circular: false # crops the image to make it circular
   image_style: "width: 600px; height: 300px;"
   more_info: >

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -25,7 +25,7 @@ let setThemeSetting = (themeSetting) => {
 let applyTheme = () => {
   let theme = determineComputedTheme();
 
-  transTheme();
+  transTheme(theme);
   setHighlight(theme);
   setGiscusTheme(theme);
   setSearchTheme(theme);
@@ -198,10 +198,24 @@ let setSearchTheme = (theme) => {
   }
 };
 
-let transTheme = () => {
+let setProfilePicture = (theme) => {
+  const profileImageWithTheme = document.getElementById('profile-image-theme');
+  if (profileImageWithTheme) {
+    const lightImage = profileImageWithTheme.getAttribute('data-light');
+    const darkImage = profileImageWithTheme.getAttribute('data-dark');
+    if (theme === "dark") {
+      profileImageWithTheme.src = darkImage;
+    } else {
+      profileImageWithTheme.src = lightImage;
+    }
+  }
+}
+
+let transTheme = (theme) => {
   document.documentElement.classList.add("transition");
   window.setTimeout(() => {
     document.documentElement.classList.remove("transition");
+    setProfilePicture(theme);
   }, 500);
 };
 


### PR DESCRIPTION
Bit hacky (shoehorned the functionality into a pretty global `theme.js` file) but added support for theme sensitive profile pics on the about page if `image_light` and `image_dark` are specified (otherwise will default to the usual behaviour of using `image`:

![2024-07-29-theme-sensitive](https://github.com/user-attachments/assets/09aca62f-295e-4a41-81c6-dd8ee774d775)
