### PR TITLE
Remove theme transition

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -25,7 +25,7 @@ let setThemeSetting = (themeSetting) => {
 let applyTheme = () => {
   let theme = determineComputedTheme();
 
-  transTheme(theme);
+  setProfilePicture(theme);
   setHighlight(theme);
   setGiscusTheme(theme);
   setSearchTheme(theme);
@@ -210,14 +210,6 @@ let setProfilePicture = (theme) => {
     }
   }
 }
-
-let transTheme = (theme) => {
-  document.documentElement.classList.add("transition");
-  window.setTimeout(() => {
-    document.documentElement.classList.remove("transition");
-    setProfilePicture(theme);
-  }, 500);
-};
 
 // Determine the expected state of the theme toggle, which can be "dark", "light", or
 // "system". Default is "system".


### PR DESCRIPTION
Removes the theme transition so that it is instantaneous:
![2024-07-29-theme-transition-removal](https://github.com/user-attachments/assets/b8c19cd8-606e-4d06-81de-cfe11bfa500c)
